### PR TITLE
Thumb captions on black bg shouldn't inherit the black body color

### DIFF
--- a/style.css
+++ b/style.css
@@ -48,6 +48,7 @@
 	width: 8em;
 	word-break: break-word;
 	background-color: rgba(32, 32, 32, 0.5);
+	color: var(--fbc-light-gray) !important;
 }
 
 .civnsfw img {


### PR DESCRIPTION
Not a big deal, but ".civmodelcard figcaption" inherit their text color from the default ".gradio-container-3-41-2 .prose *", which is the body color (#1f2937). 
That makes the caption illegible since it's displayed on a semi-transparent dark background.
I added a color instruction with the !important directive, not ideal but does the trick.