### PR TITLE
GRadio Columns scale should be of type integer

### DIFF
--- a/scripts/civitai-api.py
+++ b/scripts/civitai-api.py
@@ -871,9 +871,9 @@ def on_ui_tabs():
                 search_term = gr.Textbox(label="Search Term:", interactive=True, lines=1)
             with gr.Column(scale=2,min_width=120):
                 use_search_term = gr.Radio(label="Search:", choices=["Model name", "User name", "Tag"],value="Model name")
-            with gr.Column(scale=0.75,min_width=160 ):
+            with gr.Column(scale=1,min_width=160 ):
                 size_slider = gr.Slider(minimum=4, maximum=20, default=8, step=0.25, label='Tile size:')
-            with gr.Column(scale=0.75,min_width=160 ):
+            with gr.Column(scale=1,min_width=160 ):
                 tile_slider = gr.Slider(label="Tile count:", min=5, max=50, value=15, step=1, max_width=100)
         with gr.Row():
             with gr.Column(scale=5):


### PR DESCRIPTION
Second and last PR: the scale parameter for GRadio Columns should be an integer (cf. [the doc](https://www.gradio.app/docs/block-layouts#column)), not 0.75. I changed it to 1 instead of 0.75 to avoid the deprecation message in the console when launching Automatic1111.
As far as I can tell, it doesn't change much (check the "Tile size" / "Tile count" area) but you're probably more familiar with this than me.