### PR TITLE
Model page redesign

### DIFF
--- a/scripts/civitai_file_manage.py
+++ b/scripts/civitai_file_manage.py
@@ -57,7 +57,8 @@ def delete_model(delete_finish, content_type, model_filename, model_name, list_v
 def save_preview(preview_html, file_name, install_path):
     if not os.path.exists(install_path):
         os.makedirs(install_path)
-    img_urls = re.findall(r'src=[\'"]?([^\'" >]+)', preview_html)
+    img_urls = re.findall(r'data-preview-img=[\'"]?([^\'" >]+)', preview_html)
+
     
     if not img_urls:
         return
@@ -82,7 +83,7 @@ def save_preview(preview_html, file_name, install_path):
 def save_images(preview_html, model_filename, content_type, install_path):
     if not os.path.exists(install_path):
         os.makedirs(install_path)
-    img_urls = re.findall(r'src=[\'"]?([^\'" >]+)', preview_html)
+    img_urls = re.findall(r'data-sampleimg="true" src=[\'"]?([^\'" >]+)', preview_html)
     
     name = os.path.splitext(model_filename)[0]
 

--- a/style.css
+++ b/style.css
@@ -95,3 +95,173 @@
 	padding-top: 10px;
 	padding-bottom: 20px;
 }
+
+.model-block {
+	box-shadow: 0px 0px 1px 3px #3339ff30;
+    border-radius: 10px;
+    padding: 1px 20px 10px;
+    margin-bottom: 20px;
+}
+
+.model-block h2 {
+	/*For some reason h2 has a huge margin*/
+	margin-bottom: -10px;
+}
+
+.sampleimgs .model-block img {
+	padding-top: 1em;
+	max-width: 20em;
+	cursor: zoom-in;
+	transition: max-width 0.1s;
+}
+
+/* Preview Image zoom */
+.zoom-radio {
+    display: none!important;
+}
+
+/* Style for when the image is clicked (radio button checked) */
+.zoom-radio:checked + label > img {
+    max-width: 95vw;
+    max-height: 95vh;
+    padding-top: 0px;
+    cursor: zoom-out;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1000; /* Higher than the overlay */
+    pointer-events: none; /* Allow clicks to penetrate through to the overlay for resetting */
+}
+
+/* Overlay for resetting zoomed state */
+.zoom-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, .5); 
+    z-index: 999; /* Below the zoomed image */
+    cursor: zoom-out;
+}
+
+.zoom-radio:checked + label + .zoom-overlay {
+    display: block;
+    pointer-events: all; /* Capture click events when displayed */
+}
+
+.zoom-img-container {
+    min-width: 20em;
+}
+
+.model-uploader {
+ 	border-bottom: 1px solid;
+    padding-bottom: 10px;
+ }
+
+ .model-description {
+ 	border-top: 1px solid;
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+ }
+
+/*Avatar CSS mostly copied from CivitAI, but 48px instead of 32px*/
+.avatar {
+	user-select: none;
+    overflow: hidden;
+    width: 48px;
+    height: 48px;
+    min-width: 48px;
+    border-radius: 48px;
+    text-decoration: none;
+    border: 0;
+    padding: 0;
+    background-color: rgba(0,0,0,0.31);
+    display: inline-block!important;
+    margin-left: 5px!important;
+    vertical-align: middle;
+}
+
+.avatar img {
+	object-fit: cover;
+    width: 100%;
+    height: 100%;
+    display: block;
+    overflow-clip-margin: content-box;
+    overflow: clip;
+    border-style: none;
+    vertical-align: middle;
+}
+
+dt {
+	font-size: medium;
+    color: #80a6c8!important;
+}
+
+dd {
+	padding: 0px 0px 10px 10px;
+}
+
+/*CSS accordion for toggling extra metadata*/
+/*-----------------------------------------*/
+.accordionCheckbox {
+  position: absolute;
+  opacity: 0;
+  z-index: -1;
+}
+
+.tabs {
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.tab {
+  width: 100%;
+  color: white;
+  overflow: hidden;
+  margin-left: -15px;
+}
+
+.tab-label {
+  display: flex;
+  padding: 1em;
+  font-weight: bold;
+  cursor: pointer;
+  font-size: large;
+}
+
+/* Icon */
+.tab-label::before {
+  content: "❯";
+  width: 1em;
+  height: 1em;
+  text-align: center;
+  transition: all 0.3s;
+}
+
+.accordionCheckbox:checked + .tab-label::before {
+  transform: rotate(90deg);
+}
+
+.tab-content {
+  max-height: 0;
+  padding: 0 1em;
+  transition: all 0.3s;
+}
+
+.tab-close {
+  display: flex;
+  justify-content: flex-end;
+  padding: 1em;
+  font-size: 0.75em;
+  cursor: pointer;
+}
+
+.accordionCheckbox:checked ~ .tab-content {
+  max-height: 100vh;
+  padding: 1em;
+}
+/*-----------------------------------------*/
+/*End CSS accordion for toggling extra metadata*/


### PR DESCRIPTION
I had a lot of ideas for improvements to the model page display, so I made the changes myself. Note that I used CSS hacks for the image zoom and metadata accordion, because otherwise a more extensive rewrite would have been necessary to incorporate Gradio. (Some of the changes in this were changes I had to make in order to keep up-to-date with you while making my changes)

-   Redesigned the look of the model page.
-   Added link to model page on CivitAI. **Click on model name to open**.
-   Added link to uploader/creator page on CivitAI. **Click creator name to open**.
-   Added CivitAI avatar display.
-  Separate description section.
-   First sample image is marked with data attribute and downloaded as preview image instead of grabbing first in model HTML. This guarantees that the first sample image (not avatar or image in description) is used when downloading the model.
-   Sample images are marked with data attribute so that only they are downloaded when using "Save Images" (no description images or avatar).
-   Removed trained tags from info since they are displayed above.
-   Each sample image has its own section.
 -   Sample images zoom in when clicked, zoom out when clicking anywhere.
-   Forced width is removed from sample image URLs so that nice big images can be viewed.
-   Metadata is arranged so that the most commonly used data is at the top, no more searching for prompts.
-   Extra metadata is in accordion labeled "More details...". This is especially useful to hide insanely large ComfyUI JSON.

Info block that contains clickable model name, creator name, and displays info in an easy-to-parse way.
<img width="701" alt="image" src="https://github.com/BlafKing/sd-civitai-browser-plus/assets/3925151/4380654c-0f21-4fda-8f9b-5f744694705a">

Image block
<img width="602" alt="image" src="https://github.com/BlafKing/sd-civitai-browser-plus/assets/3925151/432eadc4-17e8-4ba9-856a-fbec98815880">

Extra metadata section expanded
<img width="907" alt="image" src="https://github.com/BlafKing/sd-civitai-browser-plus/assets/3925151/ac75a0cf-8699-4812-8406-cc77a5ade9c0">

Zoomed in image, modal style
<img width="1043" alt="image" src="https://github.com/BlafKing/sd-civitai-browser-plus/assets/3925151/94012c6d-ddcd-4247-8336-9c626a868eaa">
