### PR TITLE
Force lengthy code blocks to break properly

### DIFF
--- a/style.css
+++ b/style.css
@@ -295,6 +295,10 @@
     margin-bottom: 20px;
 }
 
+#civitai_preview_html .model-block code {
+    white-space: pre-wrap;
+}
+
 #civitai_preview_html .sampleimgs .model-block img,
 #civitai_preview_html .sampleimgs .model-block video {
 	padding-top: 1em;


### PR DESCRIPTION
Some uploaders put extended code blocks with no breaks in the description, which extends past the parent element. This fixes that.

See: https://civitai.com/models/174967 (or search for "Dragonkin" in the browser).