### PR TITLE
Prevent ridiculously long prompts with no line breaks from escaping element width

### DIFF
--- a/style.css
+++ b/style.css
@@ -299,6 +299,10 @@
     white-space: pre-wrap;
 }
 
+#civitai_preview_html .model-block dl {
+    overflow-wrap: anywhere;
+}
+
 #civitai_preview_html .sampleimgs .model-block img,
 #civitai_preview_html .sampleimgs .model-block video {
 	padding-top: 1em;


### PR DESCRIPTION
See [DiTerlizziArtAI](https://civitai.com/models/181170) for an example.