### PR TITLE
Allow local images to work with local HTML files.

### DIFF
--- a/scripts/civitai_api.py
+++ b/scripts/civitai_api.py
@@ -623,6 +623,12 @@ def cleaned_name(file_name):
     return f"{clean_name}{extension}"
 
 def fetch_and_process_image(image_url):
+    use_local = getattr(opts, "local_path_in_html", False)
+    if use_local:
+        image = Image.open(image_url)
+        geninfo, _ = read_info_from_image(image)
+        return geninfo
+    
     response = requests.get(image_url)
     if response.status_code == 200:
         image = Image.open(BytesIO(response.content))

--- a/scripts/civitai_file_manage.py
+++ b/scripts/civitai_file_manage.py
@@ -345,7 +345,6 @@ def gen_sha256(file_path):
 def convert_local_images(html):
     soup = BeautifulSoup(html)
     for simg in soup.find_all("img", attrs={"data-sampleimg": "true"}):
-        print("Found image")
         url = urlparse(simg["src"])
         path = url.path
         if not os.path.exists(path):
@@ -363,7 +362,6 @@ def convert_local_images(html):
         if not imgtype:
             imgtype = "PNG"
         simg["src"] = f"data:image/{imgtype};base64,{b64img}"
-        print("Converted image to base64")
     return str(soup)
 
 def model_from_sent(model_name, content_type, tile_count, path_input):

--- a/scripts/civitai_gui.py
+++ b/scripts/civitai_gui.py
@@ -1080,7 +1080,7 @@ def on_ui_settings():
             "Use local images in the HTML",
             section=browser,
             **({'category_id': cat_id} if ver_bool else {})
-        ).info("Does not work in combination with the \"Use local HTML file for model info\" option!")
+        )
     )
     
     shared.opts.add_option(


### PR DESCRIPTION
Really appreciate the recent changes that let you cache the images locally instead of having to reconnect to Civitai. I noticed you left off the ability to have the local HTML use the local images, possibly because browser security makes it annoying to get right. This PR gets around that by loading the images in the Python side of the code and sticking them into the Gradio output directly by base64'ing them, therefore the browser security policy never gets involved since it's all done behind-the-scenes from it. The "send to text2img" button still works; as far as I can tell everything else still works, but I was only able to test on my own installation so do whatever testing you feel is appropriate.