### PR TITLE
Temp. fix due to changes to Civitai Rest API

### DIFF
--- a/scripts/civitai_api.py
+++ b/scripts/civitai_api.py
@@ -757,7 +757,7 @@ def update_model_info(model_string=None, model_version=None, only_html=False, in
                 img_html = '<div class="sampleimgs"><input type="radio" name="zoomRadio" id="resetZoom" class="zoom-radio" checked>'
                 for index, pic in enumerate(selected_version['images']):
                     meta_button = False
-                    meta = pic['meta']
+                    meta = pic['metadata']
                     if meta and meta.get('prompt'):
                         meta_button = True
                     BtnImage = True 


### PR DESCRIPTION
This is just a dirty fix to make the extension work again until a better fix is implemented: feel free to just close this if it could be done in a different way.
As mentioned in BlafKing/sd-civitai-browser-plus#210 it is due to removal of prompt information in the model info request (changes in the Rest API made here Civitai/Civitai@c88063a3d2caad93a62d5efa3a2ac7ce7dc77b87). Since the response doesn't contain 'meta' anymore it errors out. This allows the extension to properly work, despite not being able to retrieve the prompt information. Instead of requesting 'meta', it requests 'metadata' which only includes the image file hash and its size.