### PR TITLE
add modelVersionId to model json

### DIFF
--- a/scripts/civitai_file_manage.py
+++ b/scripts/civitai_file_manage.py
@@ -689,7 +689,7 @@ def get_models(file_path, gen_hash=None):
         except Exception as e:
             print(f"Failed to open {json_file}: {e}")
     
-    if not modelId or not sha256:
+    if not modelId or not modelVersionId or not sha256:
         if gen_hash:
             if not sha256:
                 sha256 = gen_sha256(file_path)

--- a/scripts/civitai_file_manage.py
+++ b/scripts/civitai_file_manage.py
@@ -672,6 +672,7 @@ def find_and_save(api_response, sha256=None, file_name=None, json_file=None, no_
 
 def get_models(file_path, gen_hash=None):
     modelId = None
+    modelVersionId = None
     sha256 = None
     json_file = os.path.splitext(file_path)[0] + ".json"
     if os.path.exists(json_file):
@@ -681,6 +682,8 @@ def get_models(file_path, gen_hash=None):
                 
                 if 'modelId' in data:
                     modelId = data['modelId']
+                if 'modelVersionId' in data:
+                    modelVersionId = data['modelVersionId']
                 if 'sha256' in data and data['sha256']:
                     sha256 = data['sha256']
         except Exception as e:
@@ -698,7 +701,7 @@ def get_models(file_path, gen_hash=None):
                 return None
     proxies, ssl = _api.get_proxies()
     try:
-        if not modelId:
+        if not modelId or not modelVersionId:
             response = requests.get(by_hash, timeout=(60,30), proxies=proxies, verify=ssl)
             if response.status_code == 200:
                 api_response = response.json()
@@ -707,6 +710,7 @@ def get_models(file_path, gen_hash=None):
                     return None
                 else:
                     modelId = api_response.get("modelId", "")
+                    modelVersionId = api_response.get("id", "")
             elif response.status_code == 503:
                 return "offline"
             elif response.status_code == 404:
@@ -719,6 +723,7 @@ def get_models(file_path, gen_hash=None):
                         data = json.load(f)
 
                     data['modelId'] = modelId
+                    data['modelVersionId'] = modelVersionId
                     data['sha256'] = sha256.upper()
                         
                     with open(json_file, 'w', encoding="utf-8") as f:
@@ -728,6 +733,7 @@ def get_models(file_path, gen_hash=None):
             else:
                 data = {
                     'modelId': modelId,
+                    'modelVersionId': modelVersionId,
                     'sha256': sha256.upper()
                     }
                 with open(json_file, 'w', encoding="utf-8") as f:


### PR DESCRIPTION
I'm working on a [change](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15712) to stable-diffusion-webui to automatically parse the model weights from the "Civitai resources" json when using buttons such as "Send to txt2img". An example of civitai resources json:
```
Civitai resources: [{"type":"checkpoint","modelVersionId":290640},{"type":"ImageJobNetworkParams { Strength = 0.4, TriggerWord = , Type = lora }","weight":0.4,"modelVersionId":135867},
{"type":"embed","modelVersionId":250708}]
```
Note the desired Loras are specified by `modelVersionId`. Currently only the modelId is saved to the model json by the extension, so this change just adds the modelVersionId as well.