### PR TITLE
Fix compatibility with SD.Next ModernUI

### DIFF
--- a/scripts/civitai_gui.py
+++ b/scripts/civitai_gui.py
@@ -217,7 +217,7 @@ def on_ui_tabs():
                 download_progress = gr.HTML(value='<div style="min-height: 0px;"></div>', elem_id="DownloadProgress")
             with gr.Row():
                 list_models = gr.Dropdown(label="Model:", choices=[], interactive=False, elem_id="quicksettings1", value=None)
-                list_versions = gr.Dropdown(label="Version:", choices=[], interactive=False, elem_id="quicksettings", value=None)
+                list_versions = gr.Dropdown(label="Version:", choices=[], interactive=False, elem_id="quicksettings0", value=None)
                 file_list = gr.Dropdown(label="File:", choices=[], interactive=False, elem_id="file_list", value=None)
             with gr.Row():
                 with gr.Column(scale=4):

--- a/style.css
+++ b/style.css
@@ -55,7 +55,7 @@
 
 /* End of Card list HTML */
 
-#quicksettings > div{
+#quicksettings0 > div{
 	max-width: None !important;
 	width: auto !important;
 }
@@ -107,7 +107,7 @@
     z-index: 60;
 }
 
-.acss-14flpmm .gap:has(#quicksettings):first-child {
+.acss-14flpmm .gap:has(#quicksettings0):first-child {
     gap: var(--layout-gap);
 }
 


### PR DESCRIPTION
Renamed quicksettings to quicksettings0, which seems to fix : https://github.com/BlafKing/sd-civitai-browser-plus/issues/294.
Not sure this breaks anything on AUTOMATIC1111/stable-diffusion-webui, I have no way to test it.