### PR TITLE
Fix local html file path resolution from the model name

### DIFF
--- a/scripts/civitai_file_manage.py
+++ b/scripts/civitai_file_manage.py
@@ -386,7 +386,7 @@ def model_from_sent(model_name, content_type):
         folder = _api.contenttype_folder(content_type_item)
         for folder_path, _, files in os.walk(folder, followlinks=True):
             for file in files:
-                if file.startswith(model_name) and file.endswith(tuple(extensions)):
+                if (not model_file or len(file) > len(model_file)) and file.startswith(model_name) and file.endswith(tuple(extensions)):
                     model_file = os.path.join(folder_path, file)
                     
     if not model_file:


### PR DESCRIPTION
When having two models with these names (an example):
dreamshaper_8
dreamshaper_8Inpainting

When resolving the html file name (using existing code) for the model dreamshaper_8, the file that is guessed might be dreamshaper_8Inpainting.html. And the wrong locale html is loaded for the model ...

This pull request addresses the issue by adding a test to check the length of the matched file, which should fix the issue for most of the use cases. 
Arguably, this is not ideal as there might be some edge cases where this doesn't fix the issue. But, this will fix most of the issues and is definitely better that what we have now.