### PR TITLE
Improve formatting for downloaded model descriptions

### DIFF
--- a/scripts/civitai_file_manage.py
+++ b/scripts/civitai_file_manage.py
@@ -621,9 +621,12 @@ def clean_description(desc):
 
         soup = BeautifulSoup(desc, 'html.parser')
         for a in soup.find_all('a', href=True):
-            link_text = a.text + ' ' + a['href']
-            if not is_image_url(a['href']):
-                a.replace_with(link_text)
+            hyperlink_url = a['href']
+
+            # Only add the URL to the text if the hyperlink text is different from its URL
+            # Otherwise, we end up with a duplicate URL in the description
+            if a.text != hyperlink_url and not is_image_url(hyperlink_url):
+                a.replace_with(f"{a.text} ({hyperlink_url})")
 
         # Add whitespace for paragraph blocks
         for p in soup.find_all('p'):

--- a/scripts/civitai_file_manage.py
+++ b/scripts/civitai_file_manage.py
@@ -613,11 +613,27 @@ def is_image_url(url):
 
 def clean_description(desc):
     try:
+        # Add whitespace for headers and line breaks (<br>)
+        for element in ('h1', 'h2', 'h3', 'h4', 'h5', 'h6'):
+            desc = desc.replace(f'</{element}>', f'</{element}>\n')
+        desc = desc.replace('<br>', '\n\n')
+        desc = desc.replace('</br>', '\n\n')
+
         soup = BeautifulSoup(desc, 'html.parser')
         for a in soup.find_all('a', href=True):
             link_text = a.text + ' ' + a['href']
             if not is_image_url(a['href']):
                 a.replace_with(link_text)
+
+        # Add whitespace for paragraph blocks
+        for p in soup.find_all('p'):
+            # Some descriptions have empty paragraph blocks with no text (like <p></p>)
+            # usually indicating a double newline.
+            if p.text == '':
+                p.replace_with(p.text + '\n\n')
+            # For all other <p> blocks, use a single newline.
+            else:
+                p.replace_with(p.text + '\n\n')
 
         cleaned_text = soup.get_text()
     except ImportError:


### PR DESCRIPTION
Currently, formatting for model descriptions is pretty basic. This PR aims to add a little bit more formatting to improve readability.

- Adds newlines for common line-breaking elements.
- Fixes URLs appearing twice.

Before:
![before](https://github.com/user-attachments/assets/209648d6-3210-4cd7-8860-40d2f3d740ec)

After:
![after](https://github.com/user-attachments/assets/4797615c-e72c-422d-af10-3763c6019b04)
